### PR TITLE
Fix Vercel Flask import error and default scan=true

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -122,7 +122,7 @@ def catch_all(path):
     resp = Response(
         make_svg(
             request.args.get('spin'),
-            request.args.get('scan'),
+            request.args.get('scan', 'true'),
             request.args.get('theme'),
             request.args.get('rainbow'),
         ),

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.2.2
-python-dotenv==0.21.0
-requests==2.28.1
+Flask==3.0.3
+python-dotenv==1.0.1
+requests==2.31.0

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "source": "/",
+      "destination": "/api?scan=true",
+      "permanent": false
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,8 @@
 {
-  "redirects": [
+  "rewrites": [
     {
       "source": "/",
-      "destination": "/api?scan=true",
-      "permanent": false
+      "destination": "/api"
     }
   ]
 }


### PR DESCRIPTION
- Bumped Flask to 3.0.3, requests to 2.31.0, and python-dotenv to 1.0.1 in `api/requirements.txt` to fix the `cannot import name 'url_quote' from 'werkzeug.urls'` error in newer versions of Werkzeug that Vercel uses.
- Modified `api/index.py` to default the `scan` argument to `'true'` if it is not provided in the query string, making the base URL behave as `?scan=true`.

---
*PR created automatically by Jules for task [12458707216527273192](https://jules.google.com/task/12458707216527273192) started by @Lunchb0ne*

## Summary by Sourcery

Update API dependencies and adjust default request behaviour for the SVG endpoint.

Enhancements:
- Default the SVG endpoint's scan query parameter to true when not provided.

Build:
- Update Flask and python-dotenv versions in API requirements to align with newer Werkzeug used by Vercel.

Deployment:
- Add Vercel configuration file for deploying the service.