### PR TITLE
Handle podcast episodes with default artwork fallback

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -84,16 +84,22 @@ def get_scan_code(spotify_uri):
 
 def make_svg(spin, scan, theme, rainbow):
     '''Render the HTML template with variables'''
-    if data := spotify_request('me/player/currently-playing'):
+    if data := spotify_request('me/player/currently-playing?additional_types=episode'):
         item = data['item']
     else:
         item = spotify_request(
             'me/player/recently-played?limit=3')['items'][0]['track']
 
-    if item['album']['images'] == []:
+    if item.get('type') == 'episode':
+        images = item.get('images') or item.get('show', {}).get('images', [])
+        artist = item.get('show', {}).get('name', 'Podcast')
+    else:
+        images = item.get('album', {}).get('images', [])
+        artist = item.get('artists', [{}])[0].get('name', 'Unknown Artist')
+    if not images:
         image = B64_PLACEHOLDER_IMAGE
     else:
-        image = load_image_base64(item['album']['images'][1]['url'])
+        image = load_image_base64(images[min(1, len(images) - 1)]['url'])
     if scan and scan != 'false' and scan != '0':
         bar_count = 10
         scan_code = get_scan_code(item['uri'])
@@ -102,7 +108,7 @@ def make_svg(spin, scan, theme, rainbow):
         scan_code = None
     return render_template('index.html', **{
         'bars': generate_bars(bar_count, rainbow),
-        'artist': item['artists'][0]['name'],
+        'artist': artist,
         'song': item['name'],
         'image': image,
         'scan_code': scan_code if scan_code != '' else B64_PLACEHOLDER_SCAN_CODE,

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/",
+      "source": "/(.*)",
       "destination": "/api"
     }
   ]


### PR DESCRIPTION
This incorporates the work from PR #4 to properly format podcasts and use appropriate fallback pictures, and includes the upstream commit fix adding `?additional_types=episode` so that the API actually returns podcasts.

---
*PR created automatically by Jules for task <a href="https://jules.google.com/task/6890296697137313598">6890296697137313598</a> started by @Lunchb0ne*

## Summary by Sourcery

Handle Spotify podcast episodes alongside tracks, including appropriate artwork and metadata, while updating dependencies and deployment config.

New Features:
- Support rendering currently playing or recently played podcast episodes in the SVG output with proper artist/show metadata and artwork selection.

Bug Fixes:
- Ensure the currently-playing API call includes podcast episodes by requesting additional_types=episode.
- Provide a robust artwork fallback when no images are available for the playing item.

Enhancements:
- Default the scan query parameter to enabled when not specified in the request.

Build:
- Update Flask and python-dotenv dependency versions.

Deployment:
- Add Vercel configuration for deployment with a wildcard rewrite (`/(.*)`) so all routes are forwarded to the `/api` handler.

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)